### PR TITLE
Adding permanent redirects for the Constants guide

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -74,6 +74,7 @@ server {
     rewrite /contributing_to_rails.html /contributing_to_ruby_on_rails.html permanent;
     rewrite /contribute.html /contributing_to_ruby_on_rails.html permanent;
     rewrite /migrations.html /active_record_migrations.html permanent;
+    rewrite /constant_autoloading_and_reloading.html /autoloading_and_reloading_constants.html permanent;
 
     root /home/rails/guides/edge;
     index index.html;


### PR DESCRIPTION
To reflect the change made in https://github.com/rails/rails/commit/34cd7e2b1a1b5be175d79c3233a97393b01b8bad