### PR TITLE
Master branch require 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 
 * RVM
 
+* `rvm install 2.2.0`
+
 * `rvm install 2.0.0-p598 --patch railsexpress -n railsexpress`
 
 * `rvm use 2.0.0-p598-railsexpress do gem install bundler -v 1.3.5 --no-rdoc --no-ri`
 
 * `rvm use 2.0.0-p598-railsexpress do gem install bundler -v 1.7.7 --no-rdoc --no-ri`
+
+* `rvm use 2.2.0 do gem install bundler -v 1.7.10 --no-rdoc --no-ri`
 
 * `kindlegen` must be in `PATH` ([download](http://www.amazon.com/gp/feature.html?docId=1000765211)))
 

--- a/lib/target/master.rb
+++ b/lib/target/master.rb
@@ -9,6 +9,14 @@ module Target
       super(short_sha1, basedir)
     end
 
+    def ruby_version
+      '2.2.0'
+    end
+
+    def bundler_version
+      '1.7.10'
+    end
+
     def install_gems
       super
 


### PR DESCRIPTION
I removed almost every compatibility code with Ruby < 2.2 and now the docs generation are failing. We need to use Ruby 2.2 to generate the documentation.