### PR TITLE
Maintain a versions.json file tracking the latest per series

### DIFF
--- a/lib/git_manager.rb
+++ b/lib/git_manager.rb
@@ -51,6 +51,12 @@ class GitManager
     end
   end
 
+  def tag_date(tag)
+    Dir.chdir("#{basedir}/master") do
+      `git for-each-ref --format="%(taggerdate:iso8601)" refs/tags/#{tag}`.chomp
+    end
+  end
+
   def short_sha1
     sha1[0, 7]
   end

--- a/test/test_docs_generator.rb
+++ b/test/test_docs_generator.rb
@@ -32,6 +32,31 @@ class TestDocsGenerator < MiniTest::Test
     end
   end
 
+  def test_version_json
+    stable_directories = %w(v3.1.2 v3.1.0 v4.2.1 v4.2.7 v5.0.0)
+    expected = '[{"series":"5.0","version":"5.0.0","date":"2000-01-01 01:12:23 +0100"},'\
+                '{"series":"4.2","version":"4.2.7","date":"2000-01-01 01:12:23 +0100"},'\
+                '{"series":"3.1","version":"3.1.2","date":"2000-01-01 01:12:23 +0100"}]'
+
+    in_tmpdir do
+      mkdir 'basedir'
+      mkdir 'api'
+      mkdir 'guides'
+
+      Dir.chdir('basedir') do
+        stable_directories.each {|sd| mkdir sd}
+      end
+
+      git_manager = GitManager.new('basedir')
+
+      git_manager.stub(:tag_date, '2000-01-01 01:12:23 +0100') do
+        DocsGenerator.new('basedir', git_manager).adjust_json_for_series
+      end
+
+      assert_equal expected, File.read('api/versions.json')
+    end
+  end
+
   def test_stable_directories
     stable_directories = %w(v4.0.1 v4.1.7 v4.11.2 v3.1.2)
 

--- a/test/test_git_manager.rb
+++ b/test/test_git_manager.rb
@@ -52,6 +52,24 @@ class TestGitManager < MiniTest::Test
     end
   end
 
+  def test_tag_date
+    in_tmpdir do
+      mkdir_p 'basedir/master'
+
+      chdir 'basedir/master' do
+        create_repository
+        %w(0.9.4.1 2.3.9.pre 3.0.0_RC2 3.2.8.rc1 3.2.14 v4.0.0.beta1 4.0.1).each_with_index do |version, idx|
+          system "GIT_COMMITTER_DATE='2000-01-#{10 + idx} 01:23:45 -0200' git tag -a -m 'Release' v#{version}"
+        end
+      end
+
+      git_manager = GitManager.new('basedir')
+      assert_equal '2000-01-10 01:23:45 -0200', git_manager.tag_date('v0.9.4.1')
+      assert_equal '2000-01-14 01:23:45 -0200', git_manager.tag_date('v3.2.14')
+      assert_equal '2000-01-16 01:23:45 -0200', git_manager.tag_date('v4.0.1')
+    end
+  end
+
   def test_sha1_and_short_sha1
     in_tmpdir do
       mkdir_p 'basedir/master'


### PR DESCRIPTION
Also keep a version.js ("static JSONP"), for simple cross-domain access.

@fxn thoughts?

My intention is that we'd arrange for Apache to serve the files directly; I gather this puts them in a place they wouldn't be naturally accessible.

In truth, the "real" JSON file is more of an in-passing side effect... my immediate interest is in the JS file, which could be called from the main website.