### PR TITLE
Disable mobi generation for rails guides on edge

### DIFF
--- a/lib/generators/master.rb
+++ b/lib/generators/master.rb
@@ -17,7 +17,6 @@ module Generators
     def generate_guides
       Dir.chdir('guides') do
         rake 'guides:generate:html', 'ALL' => '1'
-        rake 'guides:generate:kindle'
       end
     end
 

--- a/test/docs_generator_test.rb
+++ b/test/docs_generator_test.rb
@@ -122,7 +122,7 @@ class DocsGeneratorTest < Minitest::Test
 
         assert_exists 'master/guides/output/index.html'
         assert_exists 'master/guides/output/index.html.gz'
-        assert_exists "master/guides/output/kindle/ruby_on_rails_guides_#{git_manager.short_sha1}.mobi"
+        refute_exists "master/guides/output/kindle/ruby_on_rails_guides_#{git_manager.short_sha1}.mobi"
 
         assert_equal File.expand_path('master/doc/rdoc'), File.readlink('api/edge')
         assert_equal File.expand_path('master/guides/output'), File.readlink('guides/edge')


### PR DESCRIPTION
The mobi generation takes a long time and it executes once for every documentation generation that during a day can be a lot of times.

Because of this the documentation server is always running the mobi generation taking 100% of CPU time in a 1 CPU machine. This means that the server doesn't have many resources to do what it should be doing, serving the documentation.

Since the edge guide change often enough that a mobi downloaded today may have wrong information tomorrow it is better to only generate the mobi in a stable release.