### PR TITLE
Configurable path that defaults to the gitignored ./checkout/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Vagrantfile
 .vagrant
+checkout/

--- a/bin/generate_docs.rb
+++ b/bin/generate_docs.rb
@@ -12,7 +12,7 @@ if ARGV.size > 1 || ARGV.first == "-h" || ARGV.first == "--help"
   exit
 end
 
-CHECKOUT_PATH = ARGV.first || File.join(File.dirname(__FILE__), '../checkout')
+CHECKOUT_PATH = ARGV.first || Dir.home
 
 unless Dir.exists?(CHECKOUT_PATH)
   FileUtils.mkdir(CHECKOUT_PATH)

--- a/bin/generate_docs.rb
+++ b/bin/generate_docs.rb
@@ -5,11 +5,23 @@ $:.unshift(File.expand_path('../lib', __dir__))
 require 'lock_file'
 require 'docs_generator'
 require 'git_manager'
+require 'fileutils'
+
+if ARGV.size > 1 || ARGV.first == "-h" || ARGV.first == "--help"
+  puts "USAGE: bin/generate_docs.rb [CHECKOUT_PATH]"
+  exit
+end
+
+CHECKOUT_PATH = ARGV.first || File.join(File.dirname(__FILE__), '../checkout')
+
+unless Dir.exists?(CHECKOUT_PATH)
+  FileUtils.mkdir(CHECKOUT_PATH)
+end
 
 LockFile.acquiring('docs_generation.lock') do
-  git_manager = GitManager.new(Dir.home)
+  git_manager = GitManager.new(CHECKOUT_PATH)
   git_manager.update_master
 
-  generator = DocsGenerator.new(Dir.home, git_manager)
+  generator = DocsGenerator.new(CHECKOUT_PATH, git_manager)
   generator.generate
 end


### PR DESCRIPTION
Prevents polluting home directory on non-CI/prod servers.

Will certainly break the CI and most prod tooling, updating the command used to `bin/generate_docs.rb ~/` fixes it.

(It's not referenced in the crontab as far as I can tell)