### PR TITLE
Add two command line options: --verbose and --target

### DIFF
--- a/bin/generate_docs.rb
+++ b/bin/generate_docs.rb
@@ -5,11 +5,44 @@ $:.unshift(File.expand_path('../lib', __dir__))
 require 'lock_file'
 require 'docs_generator'
 require 'git_manager'
+require 'fileutils'
+require 'optparse'
+
+options = {}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: bin/generate_docs.rb [-v|--verbose] [-tTARGET|--target=TARGET]"
+
+  opts.on("-v", "--verbose", "Run verbosely") do |v|
+    options[:verbose] = v
+  end
+
+  opts.on(
+    "-tTARGET",
+    "--target=TARGET",
+    "Target directory where to checkout the code, defaults to HOME"
+  ) do |t|
+    options[:target] = t
+  end
+end.parse!
+
+options[:verbose] = false if options[:verbose].nil?
+options[:target] ||= Dir.home
+options[:target].gsub!(/\/$/, '')
+
+unless Dir.exists?(options[:target])
+  FileUtils.mkdir(options[:target])
+end
 
 LockFile.acquiring('docs_generation.lock') do
-  git_manager = GitManager.new(Dir.home)
+  git_manager = GitManager.new(options[:target], verbose: options[:verbose])
   git_manager.update_master
 
-  generator = DocsGenerator.new(Dir.home, git_manager)
+  generator = DocsGenerator.new(
+    options[:target],
+    git_manager,
+    verbose: options[:verbose]
+  )
+
   generator.generate
 end

--- a/lib/docs_generator.rb
+++ b/lib/docs_generator.rb
@@ -66,9 +66,10 @@ class DocsGenerator
   #
   # @param basedir [String]
   # @param git_manager [GitManager]
-  def initialize(basedir, git_manager=GitManager.new(basedir))
+  def initialize(basedir, git_manager = GitManager.new(basedir), verbose: false)
     @basedir     = File.expand_path(basedir)
     @git_manager = git_manager
+    @verbose     = verbose
   end
 
   def generate
@@ -98,7 +99,7 @@ class DocsGenerator
   def generate_docs_for_release(tag)
     git_manager.checkout(tag)
 
-    generator = Generators::Release.new(tag, tag)
+    generator = Generators::Release.new(tag, tag, verbose: @verbose)
     generator.generate
 
     DocsCompressor.new(generator.api_output).compress
@@ -109,7 +110,12 @@ class DocsGenerator
   end
 
   def generate_edge_docs
-    generator = Generators::Master.new(git_manager.short_sha1, 'master')
+    generator = Generators::Master.new(
+      git_manager.short_sha1,
+      'master',
+      verbose: @verbose
+    )
+
     generator.generate
 
     DocsCompressor.new(generator.api_output).compress

--- a/lib/generators/base.rb
+++ b/lib/generators/base.rb
@@ -13,9 +13,14 @@ module Generators
 
     # @param target [String] A Git reference like 'v4.2.0' or a SHA1
     # @param basedir [String] A directory in which target has been checked out
-    def initialize(target, basedir)
+    def initialize(target, basedir, verbose: false)
       @target  = target
       @basedir = File.expand_path(basedir)
+      @verbose = verbose
+    end
+
+    def dev_null_unless_verbose
+      @verbose ? "" : " > /dev/null"
     end
 
     # Generates the documentation for target within basedir.
@@ -72,7 +77,7 @@ module Generators
     # @param command [String]
     # @param env [Hash{String => String}]
     def run(command, env={})
-      command = "rvm #{ruby_version} do #{command} >/dev/null"
+      command = "rvm #{ruby_version} do #{command}#{dev_null_unless_verbose}"
       log "#{env_as_assigns(env)} #{command}"
       system(env, command)
     end

--- a/lib/git_manager.rb
+++ b/lib/git_manager.rb
@@ -6,8 +6,13 @@ class GitManager
 
   attr_reader :basedir
 
-  def initialize(basedir)
+  def initialize(basedir, verbose: false)
     @basedir = File.expand_path(basedir)
+    @verbose = verbose
+  end
+
+  def q_unless_verbose
+    @verbose ? "" : "-q"
   end
 
   def remote_rails_url
@@ -18,7 +23,7 @@ class GitManager
     Dir.chdir(basedir) do
       unless Dir.exist?('master')
         log "cloning master into #{basedir}/master"
-        system "git clone -q #{remote_rails_url} master"
+        system "git clone #{q_unless_verbose} #{remote_rails_url} master"
       end
 
       Dir.chdir('master') do
@@ -29,7 +34,7 @@ class GitManager
         # does not change BUNDLED WITH is left as is, even if versions differ,
         # but since docs generation is automated better play safe.
         system 'git checkout Gemfile.lock'
-        system 'git pull -q'
+        system "git pull #{q_unless_verbose}"
       end
     end
   end
@@ -37,10 +42,10 @@ class GitManager
   def checkout(tag)
     Dir.chdir(basedir) do
       log "checking out tag #{tag}"
-      system "git clone -q #{remote_rails_url} #{tag}"
+      system "git clone #{q_unless_verbose} #{remote_rails_url} #{tag}"
 
       Dir.chdir(tag) do
-        system "git checkout -q #{tag}"
+        system "git checkout #{q_unless_verbose} #{tag}"
       end
     end
   end


### PR DESCRIPTION
This way it's backward compatible and still lets me see the output for easier debugging.

Supersedes #14 and could be combined with #17.