### PR TITLE
Makes docs generation work on my computer (basically)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Vagrantfile
 .vagrant
 checkout/
+docs_generation.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Vagrantfile
 .vagrant
+checkout/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Be sure to have rvm binaries in your PATH to make RVM scripting work correctly.
 set -gx PATH $HOME/.rvm/bin $PATH
 ```
 
+## Nokogiri
+
+You might need to do `bundle config build.nokogiri --use-system-libraries` on macOS to have nokogiri compile.
+
 ## Deployment
 
 Just push to `master`. The cron job in the docs server pulls before invoking

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ In order to run the test suite you need a recent version of minitest:
 
 There are two tasks: The default task, `test`, tests everything except actual
 docs generation. The `test:all` task runs the entire suite including doc
-generation for a few releases, this one takes about 20 minutes in my laptop.
+generation for a few releases, this one takes about 20 minutes on my laptop.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ LC_ALL=en_US.UTF-8
 LANG=en_US.UTF-8
 ```
 
+## RVM
+
+Be sure to have rvm binaries in your PATH to make RVM scripting work correctly.
+
+- With fish shell, in `~/.config/fish/config.fish`:
+
+```
+set -gx PATH $HOME/.rvm/bin $PATH
+```
+
 ## Deployment
 
 Just push to `master`. The cron job in the docs server pulls before invoking

--- a/bin/generate_docs.rb
+++ b/bin/generate_docs.rb
@@ -5,11 +5,23 @@ $:.unshift(File.expand_path('../lib', __dir__))
 require 'lock_file'
 require 'docs_generator'
 require 'git_manager'
+require 'fileutils'
+
+if ARGV.size > 1 || ARGV.first == "-h" || ARGV.first == "--help"
+  puts "USAGE: bin/generate_docs.rb [CHECKOUT_PATH]"
+  exit
+end
+
+CHECKOUT_PATH = ARGV.first || Dir.home
+
+unless Dir.exists?(CHECKOUT_PATH)
+  FileUtils.mkdir(CHECKOUT_PATH)
+end
 
 LockFile.acquiring('docs_generation.lock') do
-  git_manager = GitManager.new(Dir.home)
+  git_manager = GitManager.new(CHECKOUT_PATH)
   git_manager.update_master
 
-  generator = DocsGenerator.new(Dir.home, git_manager)
+  generator = DocsGenerator.new(CHECKOUT_PATH, git_manager)
   generator.generate
 end

--- a/bin/generate_docs.rb
+++ b/bin/generate_docs.rb
@@ -24,6 +24,13 @@ OptionParser.new do |opts|
   ) do |t|
     options[:target] = t
   end
+
+  opts.on(
+    "--tags=TAGS",
+    "Comma-separated git tags (e.g. Rails versions) to checkout (format: vX.X.X, edge)"
+  ) do |t|
+    options[:tags] = t
+  end
 end.parse!
 
 options[:verbose] = false if options[:verbose].nil?
@@ -41,7 +48,8 @@ LockFile.acquiring('docs_generation.lock') do
   generator = DocsGenerator.new(
     options[:target],
     git_manager,
-    verbose: options[:verbose]
+    verbose: options[:verbose],
+    tags: options[:tags]
   )
 
   generator.generate

--- a/lib/docs_compressor.rb
+++ b/lib/docs_compressor.rb
@@ -2,12 +2,14 @@ require 'find'
 require 'fileutils'
 require 'shellwords'
 require 'logging'
+require 'running'
 
 # Compresses HTML, JavaScript, and CSS under the given directory, recursively.
 #
 # We do this to leverage gzip_static in nginx.
 class DocsCompressor
   include Logging
+  include Running
 
   EXTENSIONS = %w(.js .html .css)
 
@@ -40,7 +42,7 @@ class DocsCompressor
     orig = Shellwords.shellescape(file)
     dest = Shellwords.shellescape(gzname(file))
 
-    system %(gzip -c -9 #{orig} > #{dest})
+    log_and_system %(gzip -c -9 #{orig} > #{dest})
   end
 
   def compress_file?(file)

--- a/lib/docs_generator.rb
+++ b/lib/docs_generator.rb
@@ -66,9 +66,10 @@ class DocsGenerator
   #
   # @param basedir [String]
   # @param git_manager [GitManager]
-  def initialize(basedir, git_manager=GitManager.new(basedir))
+  def initialize(basedir, git_manager = GitManager.new(basedir), verbose: false)
     @basedir     = File.expand_path(basedir)
     @git_manager = git_manager
+    @verbose     = verbose
   end
 
   def generate
@@ -98,7 +99,7 @@ class DocsGenerator
   def generate_docs_for_release(tag)
     git_manager.checkout(tag)
 
-    generator = Generators::Release.new(tag, tag)
+    generator = Generators::Release.new(tag, tag, verbose: @verbose)
     generator.generate
 
     DocsCompressor.new(generator.api_output).compress
@@ -109,7 +110,12 @@ class DocsGenerator
   end
 
   def generate_edge_docs
-    generator = Generators::Master.new(git_manager.short_sha1, 'master')
+    generator = Generators::Master.new(
+      git_manager.short_sha1,
+      'master',
+      verbose: @verbose
+    )
+
     generator.generate
 
     DocsCompressor.new(generator.api_output).compress

--- a/lib/generators/base.rb
+++ b/lib/generators/base.rb
@@ -13,9 +13,14 @@ module Generators
 
     # @param target [String] A Git reference like 'v4.2.0' or a SHA1
     # @param basedir [String] A directory in which target has been checked out
-    def initialize(target, basedir)
+    def initialize(target, basedir, verbose: false)
       @target  = target
       @basedir = File.expand_path(basedir)
+      @verbose = verbose
+    end
+
+    def dev_null_unless_verbose
+      @verbose ? "" : " > /dev/null"
     end
 
     # Generates the documentation for target within basedir.
@@ -72,7 +77,7 @@ module Generators
     # @param command [String]
     # @param env [Hash{String => String}]
     def run(command, env={})
-      command = "rvm #{ruby_version} do #{command} >/dev/null"
+      command = "rvm #{ruby_version} do #{command}#{dev_null_unless_verbose}"
       log "#{env_as_assigns(env)} #{command}"
 
       if system(env, command)

--- a/lib/generators/base.rb
+++ b/lib/generators/base.rb
@@ -74,7 +74,13 @@ module Generators
     def run(command, env={})
       command = "rvm #{ruby_version} do #{command} >/dev/null"
       log "#{env_as_assigns(env)} #{command}"
-      system(env, command)
+
+      if system(env, command)
+        true
+      else
+        log "\"#{command}\" failed to execute"
+        abort
+      end
     end
 
     # Runs `bundle exec rake` with the appropriate Bundler and Ruby versions.

--- a/lib/generators/release.rb
+++ b/lib/generators/release.rb
@@ -35,6 +35,8 @@ module Generators
     end
 
     def generate_guides
+      FileUtils.mkdir('guides') unless Dir.exists?('guides')
+
       Dir.chdir('guides') do
         rake 'guides:generate:html',   'RAILS_VERSION' => target
         rake 'guides:generate:kindle', 'RAILS_VERSION' => target

--- a/lib/generators/release.rb
+++ b/lib/generators/release.rb
@@ -7,8 +7,8 @@ module Generators
   class Release < Base
     include Config::Release
 
-    def initialize(tag, basedir)
-      super(tag, basedir)
+    def initialize(tag, basedir, verbose: false)
+      super(tag, basedir, verbose: verbose)
       @version_number = VersionNumber.new(tag)
     end
 

--- a/lib/git_manager.rb
+++ b/lib/git_manager.rb
@@ -1,8 +1,10 @@
 require 'logging'
+require 'running'
 
 # Lightweight wrapper over Git, shells out everything.
 class GitManager
   include Logging
+  include Running
 
   attr_reader :basedir
 
@@ -18,7 +20,7 @@ class GitManager
     Dir.chdir(basedir) do
       unless Dir.exist?('master')
         log "cloning master into #{basedir}/master"
-        system "git clone -q #{remote_rails_url} master"
+        log_and_system "git clone -q #{remote_rails_url} master"
       end
 
       Dir.chdir('master') do
@@ -28,8 +30,8 @@ class GitManager
         # git pull from succeeding. Starting with Bundler 1.10, if Gemfile.lock
         # does not change BUNDLED WITH is left as is, even if versions differ,
         # but since docs generation is automated better play safe.
-        system 'git checkout Gemfile.lock'
-        system 'git pull -q'
+        log_and_system 'git checkout Gemfile.lock'
+        log_and_system 'git pull -q'
       end
     end
   end
@@ -37,10 +39,10 @@ class GitManager
   def checkout(tag)
     Dir.chdir(basedir) do
       log "checking out tag #{tag}"
-      system "git clone -q #{remote_rails_url} #{tag}"
+      log_and_system "git clone -q #{remote_rails_url} #{tag}"
 
       Dir.chdir(tag) do
-        system "git checkout -q #{tag}"
+        log_and_system "git checkout -q #{tag}"
       end
     end
   end

--- a/lib/git_manager.rb
+++ b/lib/git_manager.rb
@@ -8,8 +8,13 @@ class GitManager
 
   attr_reader :basedir
 
-  def initialize(basedir)
+  def initialize(basedir, verbose: false)
     @basedir = File.expand_path(basedir)
+    @verbose = verbose
+  end
+
+  def q_unless_verbose
+    @verbose ? "" : "-q"
   end
 
   def remote_rails_url
@@ -20,7 +25,7 @@ class GitManager
     Dir.chdir(basedir) do
       unless Dir.exist?('master')
         log "cloning master into #{basedir}/master"
-        log_and_system "git clone -q #{remote_rails_url} master"
+        log_and_system "git clone #{q_unless_verbose} #{remote_rails_url} master"
       end
 
       Dir.chdir('master') do
@@ -31,7 +36,7 @@ class GitManager
         # does not change BUNDLED WITH is left as is, even if versions differ,
         # but since docs generation is automated better play safe.
         log_and_system 'git checkout Gemfile.lock'
-        log_and_system 'git pull -q'
+        log_and_system "git pull #{q_unless_verbose}"
       end
     end
   end
@@ -39,10 +44,10 @@ class GitManager
   def checkout(tag)
     Dir.chdir(basedir) do
       log "checking out tag #{tag}"
-      log_and_system "git clone -q #{remote_rails_url} #{tag}"
+      log_and_system "git clone #{q_unless_verbose} #{remote_rails_url} #{tag}"
 
       Dir.chdir(tag) do
-        log_and_system "git checkout -q #{tag}"
+        log_and_system "git checkout #{q_unless_verbose} #{tag}"
       end
     end
   end

--- a/lib/running.rb
+++ b/lib/running.rb
@@ -1,0 +1,8 @@
+module Running
+  include Logging
+
+  def log_and_system(*args)
+    log(args.map(&:to_s).join(' '))
+    system(*args).tap { log "Done" }
+  end
+end


### PR DESCRIPTION
- `--verbose`, `--target` and `--tags` flags
- Changes from all the other PRs combined into one PR basically

- [x] `rake test` pass
- [x] `rake test:all` pass because doc_generator_test.rb is in "Pending." state :)

So this is mostly to give a higher level view of all the changes and it quite nicely lets me do:

```
bin/generate_docs.rb -t checkout/ -v --tags=v5.2.0
```

And then `python3 -m http.server` lets me see the generated docs.

The main thing is I'm waiting for some high-level approval on this PR before writing tests for the three new flags. Maybe trying to revive the old tests too.

(Obviously I just want to fix the links thing on the generated docs and it's related to `rdoc` but might be much more complicated to have something merged in `rdoc` than here)