### PR TITLE
Fix guide redirects

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -41,7 +41,7 @@ server {
 
     rewrite /contributing_to_rails.html /contributing_to_ruby_on_rails.html permanent;
     rewrite /contribute.html /contributing_to_ruby_on_rails.html permanent;
-    rewrite /constant_autoloading_and_reloading.html /autoloading_and_reloading_constants.html permanent;
+    rewrite ^(.*)/constant_autoloading_and_reloading.html$ $1/autoloading_and_reloading_constants.html permanent;
 
     location ~ ^/v\d {
       root /home/rails/guides;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -41,6 +41,7 @@ server {
 
     rewrite /contributing_to_rails.html /contributing_to_ruby_on_rails.html permanent;
     rewrite /contribute.html /contributing_to_ruby_on_rails.html permanent;
+    rewrite ^((?!/v[2-3]\.|/v4\.[0-1]).*)/migrations.html$ $1/active_record_migrations.html permanent;
     rewrite ^(.*)/constant_autoloading_and_reloading.html$ $1/autoloading_and_reloading_constants.html permanent;
 
     location ~ ^/v\d {


### PR DESCRIPTION
This PR is split into two commits, which solve the following problems:

1. The v4.2 and v5.0 guides are the only guides which link to `constant_autoloading_and_reloading.html`.  However, visiting that path in either version currently redirects to the stable version of `autoloading_and_reloading_constants.html`, which is a Zeitwerk guide as of Rails 6.0.

2. `migrations.html` was renamed to `active_record_migrations.html` in Rails 4.2, but the v4.2 and v5.0 guides link to the old path.  Visiting `migrations.html` in v4.2 or later, including stable, currently redirects to the edge version of `active_record_migrations.html`, which may go unnoticed and cause confusion.

:warning:  I have only tested the regexes here.  I do not have all the `rails-docs-server` dependencies installed at the moment, and so have not tested the conf itself.  I am hoping some *very generous* person will double-check these changes.  :pray:
