### PR TITLE
Insert edge badge on index.html as well

### DIFF
--- a/lib/generators/master.rb
+++ b/lib/generators/master.rb
@@ -23,17 +23,13 @@ module Generators
     private
 
     def insert_edge_badge
-      %w(classes files).each do |subdir|
-        Find.find("#{api_output}/#{subdir}") do |fname|
-          next unless fname.end_with?('.html')
-
-          # This is a bit hackish but simple enough. Future API tools would
-          # ideally have support for this like we have in the guides.
-          html = File.read(fname, encoding: 'ASCII-8BIT')
-          unless html.include?('<img src="/edge_badge.png"')
-            html.sub!(%r{<body[^>]*>}, '\\&<div><img src="/edge_badge.png" alt="edge badge" style="position:fixed;right:0px;top:0px;z-index:100;border:none;"/></div>')
-            File.write(fname, html)
-          end
+      Dir.glob("#{api_output}/**/*.html") do |fname|
+        # This is a bit hackish but simple enough. Future API tools would
+        # ideally have support for this like we have in the guides.
+        html = File.read(fname, encoding: 'ASCII-8BIT')
+        unless html.include?('<img src="/edge_badge.png"')
+          html.sub!(%r{<body[^>]*>}, '\\&<div><img src="/edge_badge.png" alt="edge badge" style="position:fixed;right:0px;top:0px;z-index:100;border:none;"/></div>')
+          File.write(fname, html)
         end
       end
 


### PR DESCRIPTION
The 'edge_badge.png' is inserted in all html pages in classes and files.
Now that index.html renders a html body instead of frames, the edge
badge should be inserted as well.

Since we can insert it in all .html files, we can use `Dir.glob` to loop
over the files and remove the extra loop and extension conditional.