### PR TITLE
Adding expiry headers to Nginx Configuration

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,9 +1,6 @@
 # Expires map
 map $sent_http_content_type $expires {
     default                    off;
-    text/html                  24h;
-    text/css                   max;
-    application/javascript     max;
     ~image/                    max;
 }
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,3 +1,12 @@
+# Expires map
+map $sent_http_content_type $expires {
+    default                    off;
+    text/html                  24h;
+    text/css                   max;
+    application/javascript     max;
+    ~image/                    max;
+}
+
 #
 # --- Stable docs --------------------------------------------------------------
 #
@@ -5,6 +14,7 @@
 server {
     server_name api.rubyonrails.org;
     gzip_static on;
+    expires $expires;
 
     location ~ ^/v\d {
       root /home/rails/api;
@@ -38,6 +48,7 @@ server {
 server {
     server_name guides.rubyonrails.org;
     gzip_static on;
+    expires $expires;
 
     rewrite /contributing_to_rails.html /contributing_to_ruby_on_rails.html permanent;
     rewrite /contribute.html /contributing_to_ruby_on_rails.html permanent;
@@ -79,6 +90,7 @@ server {
 server {
     server_name edgeapi.rubyonrails.org;
     gzip_static on;
+    expires $expires;
 
     root /home/rails/api/edge;
     index index.html;
@@ -95,6 +107,7 @@ server {
 server {
     server_name edgeguides.rubyonrails.org;
     gzip_static on;
+    expires $expires;
 
     rewrite /contributing_to_rails.html /contributing_to_ruby_on_rails.html permanent;
     rewrite /contribute.html /contributing_to_ruby_on_rails.html permanent;


### PR DESCRIPTION
# Summary

This _should_ add expiry headers to https://guides.rubyonrails.org/getting_started.html which will solve:

![image](https://user-images.githubusercontent.com/325384/109022136-717a5c00-76b3-11eb-9815-73f68a3aaa65.png)

I saw the above when I ran [Lighthouse](https://web.dev/measure/) against the current guides site.

I based the nginx config changes on [this digital ocean article](https://www.digitalocean.com/community/tutorials/how-to-implement-browser-caching-with-nginx-s-header-module-on-ubuntu-16-04).

# Other Information

I've not touched nginx configurations for a while (I normally just use Netlify & Vercel right now) & I wasn't able to confirm locally that the configuration changes are valid, plus I'm totally open to debate about if `24h` is the right level of caching for html files.