### PR TITLE
Remove edge badge hack

### DIFF
--- a/lib/generators/main.rb
+++ b/lib/generators/main.rb
@@ -10,7 +10,6 @@ module Generators
     def generate_api
       start = Time.now
       rake 'rdoc', 'EDGE' => '1', 'ALL' => '1'
-      insert_edge_badge
       delete_orphan_files_in_api(start)
     end
 
@@ -24,24 +23,6 @@ module Generators
 
     def before_generation
       run "gem install bundler"
-    end
-
-    def insert_edge_badge
-      %w(classes files).each do |subdir|
-        Find.find("#{api_output}/#{subdir}") do |fname|
-          next unless fname.end_with?('.html')
-
-          # This is a bit hackish but simple enough. Future API tools would
-          # ideally have support for this like we have in the guides.
-          html = File.read(fname, encoding: 'ASCII-8BIT')
-          unless html.include?('<img src="/edge_badge.png"')
-            html.sub!(%r{<body[^>]*>}, '\\&<div><img src="/edge_badge.png" alt="edge badge" style="position:fixed;right:0px;top:0px;z-index:100;border:none;"/></div>')
-            File.write(fname, html)
-          end
-        end
-      end
-
-      FileUtils.cp('guides/assets/images/edge_badge.png', api_output)
     end
 
     # Edge API generation does not remove doc/rdoc to easily have no downtime


### PR DESCRIPTION
Sdoc 2.4.0 supports a CSS badge that can be set by passing the version
as a env variable.
We no longer need to copy the image and insert html.

## Before

<img width="910" alt="image" src="https://user-images.githubusercontent.com/28561/167704089-5a5f78b4-da20-4350-b93b-6fcaa3192fa6.png">

## After for Edge
<img width="907" alt="image" src="https://user-images.githubusercontent.com/28561/167703896-aeb2b7b0-fe49-4ecd-8e97-c4f0b7dbbae3.png">

## After for Stable

<img width="908" alt="image" src="https://user-images.githubusercontent.com/28561/167704317-bc9662d9-1011-49ec-80e2-3f8188cc23f3.png">

## After on Mobile

<img width="492" alt="image" src="https://user-images.githubusercontent.com/28561/167704726-f070a189-30f3-45c3-b775-de11dcc365e3.png">

