### PR TITLE
Fix guides for 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 * RVM
 
+* `rvm install 3.2.5`
+
 * `rvm install 3.1.4`
 
 * `rvm install 2.7.6`
@@ -19,6 +21,8 @@
 * `rvm use 2.7.6 do gem install bundler -v 2.2.3 --no-doc`
 
 * `rvm use 3.1.4 do gem install bundler --no-doc`
+
+* `rvm use 3.2.5 do gem install bundler --no-doc`
 
 * `kindlegen` must be in `PATH` ([download](http://www.amazon.com/gp/feature.html?docId=1000765211)))
 

--- a/lib/generators/config/main.rb
+++ b/lib/generators/config/main.rb
@@ -2,7 +2,7 @@ module Generators
   module Config
     module Main
       def ruby_version
-        '3.1.4'
+        '3.2.5'
       end
 
       def api_output

--- a/lib/generators/config/release.rb
+++ b/lib/generators/config/release.rb
@@ -11,8 +11,10 @@ module Generators
           '2.5.3'
         elsif version_number < '7.2.0'
           '2.7.6'
-        else
+        elsif version_number < '8.0'
           '3.1.4'
+        else
+          '3.2.5'
         end
       end
 


### PR DESCRIPTION
Which dropped support for Ruby 3.1