### PR TITLE
Use Ruby 3.3 to fix generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 * RVM
 
-* `rvm install 3.2.5`
+* `rvm install 3.3.6`
 
 * `rvm install 3.1.4`
 
@@ -22,7 +22,7 @@
 
 * `rvm use 3.1.4 do gem install bundler --no-doc`
 
-* `rvm use 3.2.5 do gem install bundler --no-doc`
+* `rvm use 3.3.6 do gem install bundler --no-doc`
 
 * `kindlegen` must be in `PATH` ([download](http://www.amazon.com/gp/feature.html?docId=1000765211)))
 

--- a/lib/generators/config/main.rb
+++ b/lib/generators/config/main.rb
@@ -2,7 +2,7 @@ module Generators
   module Config
     module Main
       def ruby_version
-        '3.2.5'
+        '3.3.6'
       end
 
       def api_output

--- a/lib/generators/config/release.rb
+++ b/lib/generators/config/release.rb
@@ -14,7 +14,7 @@ module Generators
         elsif version_number < '8.0'
           '3.1.4'
         else
-          '3.2.5'
+          '3.3.6'
         end
       end
 


### PR DESCRIPTION
Similar to #29, have manually verified this on the server:

```
$ FORCE=1 bin/rails_master_hook.sh

[2025-01-06 07:07:51 UTC]  rvm 3.3.6 do gem install bundler >/dev/null
[2025-01-06 07:08:01 UTC]  rvm 3.3.6 do bundle install --without db test job cable storage ujs >/dev/null
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do
in future versions. Instead please use `bundle config set without 'db test job cable storage ujs'`, and stop using this flag
[2025-01-06 07:08:04 UTC] EDGE="1" ALL="1" rvm 3.3.6 do bundle exec rake rdoc >/dev/null

Generating API format into /home/rails/main/doc/rdoc...
[2025-01-06 07:10:37 UTC] ALL="1" rvm 3.3.6 do bundle exec rake guides:generate:html >/dev/null
/home/rails/.rvm/rubies/ruby-3.3.6/bin/ruby -Eutf-8:utf-8 rails_guides.rb
...
[2025-01-06 07:11:02 UTC] gzip -c -9 /home/rails/main/guides/output/working_with_javascript_in_rails.html > /home/rails/main/guides/output/working
_with_javascript_in_rails.html.gz
[2025-01-06 07:11:02 UTC] Done
[2025-01-06 07:11:02 UTC] releasing lock file docs_generation.lock
```

Sorry, I don't have time to investigate a proper fix at the moment.

/cc @skipkayhil